### PR TITLE
feat: Add Ollama support and dynamic UI model patching

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -88,6 +88,8 @@ jobs:
           file: Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          no-cache: true
+          pull: true
 
       - name: Setup Helm
         if: steps.semantic.outputs.new_release_published == 'true'

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ RUN mkdir -p -m 755 /etc/apt/keyrings && \
     rm -rf /var/lib/apt/lists/*
 
 # Install kubectl
-RUN curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.29/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg && \
-    echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.29/deb/ /' | tee /etc/apt/sources.list.d/kubernetes.list && \
+RUN curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.36/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg && \
+    echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.36/deb/ /' | tee /etc/apt/sources.list.d/kubernetes.list && \
     apt-get update && apt-get install -y kubectl && \
     rm -rf /var/lib/apt/lists/*
 
@@ -33,14 +33,35 @@ RUN wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/d
     chmod +x /usr/local/bin/yq
 
 # Install dyff
-RUN curl -sL https://github.com/homeport/dyff/releases/download/v1.9.1/dyff_1.9.1_linux_amd64.tar.gz | tar -xz -C /usr/local/bin dyff
+RUN curl -sL https://github.com/homeport/dyff/releases/download/v1.12.0/dyff_1.12.0_linux_amd64.tar.gz | tar -xz -C /usr/local/bin dyff
 
 # Install agent clis and code ui
-RUN npm install -g @anthropic-ai/claude-code @google/gemini-cli @siteboon/claude-code-ui
+RUN npm install -g @anthropic-ai/claude-code@latest @google/gemini-cli@latest @cloudcli-ai/cloudcli@latest
 
-# Configure workspace
+# Verify that the modelConstants.js file still contains the expected structure for our entrypoint patch.
+# If this fails during a nightly build, the upstream package changed and the patch in docker-entrypoint.sh needs updating.
+RUN node -e " \
+    const fs = require('fs'); \
+    const file = '/usr/local/lib/node_modules/@cloudcli-ai/cloudcli/dist-server/shared/modelConstants.js'; \
+    if (!fs.existsSync(file)) { \
+        console.error('Error: modelConstants.js not found!'); \
+        process.exit(1); \
+    } \
+    const content = fs.readFileSync(file, 'utf8'); \
+    if (!/export const CLAUDE_MODELS = \{\s*(\/\/.*)?\s*OPTIONS:\s*\[/.test(content)) { \
+        console.error('Error: Expected CLAUDE_MODELS OPTIONS structure not found in modelConstants.js. The upstream package might have changed.'); \
+        process.exit(1); \
+    } \
+    console.log('modelConstants.js verification passed.'); \
+"
+
+# Configure workspace and permissions for entrypoint patching
 RUN mkdir -p /home/node/workspace && \
-    chown -R node:node /home/node/workspace
+    chown -R node:node /home/node/workspace && \
+    chmod 666 /usr/local/lib/node_modules/@cloudcli-ai/cloudcli/dist-server/shared/modelConstants.js || true
+
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 USER node
 ENV HOME=/home/node
@@ -48,4 +69,5 @@ ENV WORKSPACE_DIR=/home/node/workspace
 
 EXPOSE 3001
 
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["cloudcli"]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains a containerized version of [Claude Code UI](https://git
 It includes a complete set of command-line tools commonly used alongside these agents, such as `gh`, `kubectl`, `jq`, `yq`, and `dyff`. The repository also provides a Helm chart to deploy the application easily into a Kubernetes environment with persistent storage for agent configuration files.
 
 ## Features
-- **Docker Image**: Bundles `node`, `siteboon/claudecodeui`, Anthropic's `claude-code`, Google's `gemini` cli, GitHub CLI, and various system utilities.
+- **Docker Image**: Bundles `node`, `@cloudcli-ai/cloudcli`, Anthropic's `claude-code`, Google's `gemini` cli, GitHub CLI, and various system utilities.
 - **Helm Chart**: Ready-to-use chart for deploying to Kubernetes (`k3s`).
 - **CI/CD**: Fully automated Nightly & Release pipelines via GitHub Actions.
 - **Rootless & Secure**: Designed with best practices, avoiding Alpine in favor of `node:22-bookworm-slim` for broader compatibility, and utilizing read-only ServiceAccounts for `kubectl`.
@@ -24,6 +24,11 @@ image:
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
+
+ollama:
+  enabled: true
+  url: "http://ollama.ai-services.svc.cluster.local:11434"
+  model: "qwen2.5-coder:7b"
 
 persistence:
   enabled: true

--- a/charts/claudecodeui/templates/deployment.yaml
+++ b/charts/claudecodeui/templates/deployment.yaml
@@ -40,6 +40,17 @@ spec:
           {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.ollama.enabled }}
+          env:
+            - name: ANTHROPIC_BASE_URL
+              value: {{ .Values.ollama.url | quote }}
+            - name: ANTHROPIC_API_KEY
+              value: "ollama"
+            - name: ANTHROPIC_MODEL
+              value: {{ .Values.ollama.model | quote }}
+            - name: CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC
+              value: "1"
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.targetPort | default 3001 }}

--- a/charts/claudecodeui/values.yaml
+++ b/charts/claudecodeui/values.yaml
@@ -69,3 +69,10 @@ volumeMounts: []
 nodeSelector: {}
 tolerations: []
 affinity: {}
+
+ollama:
+  enabled: false
+  # URL to your local Ollama instance (do not include /v1, the SDK appends it)
+  url: "http://ollama.ai-services.svc.cluster.local:11434"
+  # Name of the model downloaded in Ollama
+  model: "qwen2.5-coder:7b"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+set -e
+
+# Patch the cloudcli models to include ANTHROPIC_MODEL if set
+if [ -n "$ANTHROPIC_MODEL" ]; then
+  cat << 'EOF' > /tmp/patch_models.js
+const fs = require('fs');
+const file = '/usr/local/lib/node_modules/@cloudcli-ai/cloudcli/dist-server/shared/modelConstants.js';
+if (fs.existsSync(file)) {
+  let content = fs.readFileSync(file, 'utf8');
+  const model = process.env.ANTHROPIC_MODEL;
+  if (!content.includes('value: "' + model + '"')) {
+    if (content.includes('export const CLAUDE_MODELS = {')) {
+      content = content.replace(
+        /export const CLAUDE_MODELS = \{\s*(\/\/.*)?\s*OPTIONS:\s*\[/, 
+        'export const CLAUDE_MODELS = {\n    OPTIONS: [\n        { value: "' + model + '", label: "Ollama: ' + model + '" },'
+      );
+      try {
+        fs.writeFileSync(file, content);
+        console.log('Patched cloudcli models to include: ' + model);
+      } catch (e) {
+        console.error('Failed to patch model constants: ' + e.message);
+      }
+    }
+  }
+}
+EOF
+  node /tmp/patch_models.js
+fi
+
+exec "$@"


### PR DESCRIPTION
This PR adds full support for Ollama models in the cloudcli/claude-code-ui. It includes:

- Helm chart values for Ollama URL and model configuration.
- A Dockerfile patch that ensures the container fetches fresh dependencies without hitting Docker cache issues.
- An entrypoint script that dynamically patches the upstream \modelConstants.js\ to inject the specified Ollama model so that it appears in the chat UI's model selection dropdown.
- A verification step in the Dockerfile to fail the nightly build if the upstream package structure changes, alerting us to update the patch.