### PR TITLE
fix: resolve Claude Code auth prompt when CCR is enabled

### DIFF
--- a/charts/claudecodeui/Chart.yaml
+++ b/charts/claudecodeui/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.0
+version: 1.2.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/claudecodeui/templates/deployment.yaml
+++ b/charts/claudecodeui/templates/deployment.yaml
@@ -69,6 +69,12 @@ spec:
           env:
             - name: CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC
               value: "1"
+            - name: ANTHROPIC_BASE_URL
+              value: "http://127.0.0.1:3456"
+            - name: CLAUDE_CODE_API_BASE_URL
+              value: "http://127.0.0.1:3456"
+            - name: ANTHROPIC_API_KEY
+              value: "sk-ant-ccr-dummy"
           {{- end }}
           ports:
             - name: http

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -7,6 +7,8 @@ if [ -f "$CCR_CONFIG_PATH" ]; then
   echo "CCR configuration detected. Starting Claude Code Router..."
   ccr start &
   export ANTHROPIC_BASE_URL="http://127.0.0.1:3456"
+  export CLAUDE_CODE_API_BASE_URL="http://127.0.0.1:3456"
+  export ANTHROPIC_API_KEY="sk-ant-ccr-dummy"
 fi
 
 exec "$@"


### PR DESCRIPTION
This PR adds the necessary environment variables (ANTHROPIC_API_KEY, ANTHROPIC_BASE_URL) to satisfy the Claude Code CLI when using the Claude Code Router. This prevents the CLI from prompting for an API key during startup.