### PR TITLE
bump to 1 4 0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,13 +53,22 @@ jobs:
         if: steps.semantic.outputs.new_release_published == 'true'
         run: |
           NEW_VERSION=${{ steps.semantic.outputs.new_release_version }}
+          echo "Updating Helm chart to version $NEW_VERSION"
+          
           yq e -i ".appVersion = \"$NEW_VERSION\"" charts/claudecodeui/Chart.yaml
           yq e -i ".version = \"$NEW_VERSION\"" charts/claudecodeui/Chart.yaml
           yq e -i ".image.tag = \"$NEW_VERSION\"" charts/claudecodeui/values.yaml
           
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          
           git add charts/claudecodeui/Chart.yaml charts/claudecodeui/values.yaml
-          git commit -m "chore(release): update helm chart to $NEW_VERSION [skip ci]" || echo "No changes to commit"
-          git push
+          if git diff --staged --quiet; then
+            echo "No changes to Helm chart files"
+          else
+            git commit -m "chore(release): update helm chart to $NEW_VERSION [skip ci]"
+            git push origin main
+          fi
 
       - name: Login to GitHub Container Registry
         if: steps.semantic.outputs.new_release_published == 'true'

--- a/charts/claudecodeui/Chart.yaml
+++ b/charts/claudecodeui/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.1
+version: 1.4.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.3.1"
+appVersion: "1.4.0"

--- a/charts/claudecodeui/values.yaml
+++ b/charts/claudecodeui/values.yaml
@@ -5,7 +5,7 @@ image:
   repository: ghcr.io/ryanbeales/claudecodeui-container
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "1.3.1"
+  tag: "1.4.0"
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
- chore: bump version to 1.4.0
- feat: automate helm chart version sync in release workflow
